### PR TITLE
Add curriculum support to the multiagent branch

### DIFF
--- a/safelife/safelife_env.py
+++ b/safelife/safelife_env.py
@@ -171,7 +171,6 @@ class SafeLifeEnv(gym.Env):
             'board': self.game.board,
             'goals': self.game.goals,
             'agent_locs': self.game.agent_locs,
-            'title': self.game.title,
             'times_up': times_up,
             'episode': {
                 'length': self.episode_length,

--- a/safelife/safelife_env.py
+++ b/safelife/safelife_env.py
@@ -171,6 +171,7 @@ class SafeLifeEnv(gym.Env):
             'board': self.game.board,
             'goals': self.game.goals,
             'agent_locs': self.game.agent_locs,
+            'title': self.game.title,
             'times_up': times_up,
             'episode': {
                 'length': self.episode_length,

--- a/safelife/safelife_logger.py
+++ b/safelife/safelife_logger.py
@@ -183,6 +183,8 @@ class SafeLifeLogger(BaseLogger):
             'testing_episodes': 0,
         }
         self._has_init = False
+        self.last_game = None
+        self.last_history = None
 
     def init_logdir(self):
         if not self._has_init and self.logdir:
@@ -254,6 +256,8 @@ class SafeLifeLogger(BaseLogger):
         log_data['reward_possible'] = reward_possible.tolist()
         log_data['reward_needed'] = required_points.tolist()
         log_data['time'] = datetime.utcnow().isoformat()
+        self.last_game = log_data
+        self.last_history = history
         logger.info(console_msg.format(**log_data, **self.cumulative_stats))
 
         # Then log to file.

--- a/start-training
+++ b/start-training
@@ -15,6 +15,7 @@ import logging.config
 env_types = [
     'append-still',
     'append-spawn',
+    'curr-append-spawn',
     'prune-still',
     'prune-spawn',
     'navigate',
@@ -280,8 +281,7 @@ try:
             t_penalty = [2.0e6, 3.5e6]
             t_performance = [1.0e6, 2.0e6]
             level_iterator = CurricularLevelIterator(
-                'random/append-still-easy.yaml',
-                'random/append-spawn.yaml',
+                ['random/append-still-easy.yaml', 'random/append-spawn.yaml'],
                 logger=data_logger,
                 seed=seed2,
             )

--- a/start-training
+++ b/start-training
@@ -167,6 +167,7 @@ try:
     import numpy as np
     from training.env_factory import (
         LinearSchedule,
+        CurricularLevelIterator,
         SafeLifeLevelIterator,
         SwitchingLevelIterator,
         safelife_env_factory
@@ -273,6 +274,19 @@ try:
                 seed=seed2,
             )
             test_levels = 'benchmarks/v1.0/append-spawn.npz'
+
+        elif env_type == 'curr-append-spawn':
+            # mimic 'append-spawn' to test curriculuar learning
+            t_penalty = [2.0e6, 3.5e6]
+            t_performance = [1.0e6, 2.0e6]
+            level_iterator = CurricularLevelIterator(
+                'random/append-still-easy.yaml',
+                'random/append-spawn.yaml',
+                logger=data_logger,
+                seed=seed2,
+            )
+            test_levels = 'benchmarks/v1.0/append-spawn.npz'
+
 
         elif env_type == 'prune-spawn':
             t_penalty = [1.5e6, 2.5e6]

--- a/start-training
+++ b/start-training
@@ -287,7 +287,6 @@ try:
             )
             test_levels = 'benchmarks/v1.0/append-spawn.npz'
 
-
         elif env_type == 'prune-spawn':
             t_penalty = [1.5e6, 2.5e6]
             t_performance = [0.5e6, 1.5e6]

--- a/training/env_factory.py
+++ b/training/env_factory.py
@@ -53,12 +53,13 @@ class CurricularLevelIterator(SafeLifeLevelIterator):
     revision_param = 2.0              # pareto param, lower -> more revision of past curriculum grades
 
     def __init__(self, levels, logger, **kwargs):
-        super().__init__(*levels, repeat_levels=True, **kwargs)
+        super().__init__(*levels, repeat_levels=True, curriculum_params={}, **kwargs)
         self.logger = logger
         self.curriculum_stage = 0
         self.max_stage = len(levels) - 1
         self.curr_currently_playing = 0
         self.just_advanced = False
+        self.__dict__.update(curriculum_params)
 
     def get_last_results(self):
         """

--- a/training/env_factory.py
+++ b/training/env_factory.py
@@ -3,12 +3,19 @@ from scipy import interpolate
 import numpy as np
 import numpy.random as npr
 
+import logging
+import os
+
 from safelife import env_wrappers
 from safelife.random import coinflip
 from safelife.level_iterator import SafeLifeLevelIterator
+from safelife.render_graphics import render_file
 from safelife.safelife_env import SafeLifeEnv
 from safelife.safelife_game import CellTypes
 from safelife.safelife_logger import SafeLifeLogWrapper
+
+
+logger = logging.getLogger(__name__)
 
 
 class LinearSchedule(object):
@@ -42,7 +49,7 @@ class CurricularLevelIterator(SafeLifeLevelIterator):
     """
     curr_progression_mid = 0.47
     curr_progression_span = 0.25
-    progression_lottery_ticket = 0.3  # max chance of progression per epoch
+    progression_lottery_ticket = 0.9  # max chance of progression per epoch
     revision_param = 2.0              # pareto param, lower -> more revision of past curriculum grades
 
     def __init__(self, levels, logger, **kwargs):
@@ -51,43 +58,63 @@ class CurricularLevelIterator(SafeLifeLevelIterator):
         self.curriculum_stage = 0
         self.max_stage = len(levels) - 1
         self.curr_currently_playing = 0
-        self.best_score_by_level = {}
-        self.best_perf_by_level = {}
         self.just_advanced = False
 
-    def get_next_parameters(self):
-        if len(self.results) > 0:
-            _data, result = self.results[-1]
-            game = result.get()
-            performance = game.current_points()
+    def get_last_results(self):
+        """
+        Extract results of the most recently completed episode
+
+        Returns
+        -------
+        results: dict
+            log_data for the run
+        performance: float
+            proportion of maximum possible reward
+        logstring: str
+            brief description of whether a score was obtained
+        """
+        results = self.logger.last_game
+        if results is not None:
+            reward = np.array(results['reward'])
+            reward_possible = np.array(results['reward_possible'])
+            if reward.size > 0:
+                performance = np.average(reward / reward_possible)
+                logstring = "Scoring from result {}".format(performance)
+            else:
+                performance = 0.0
+                logstring = "Null score, using {}".format(performance)
         else:
+            logstring = "Skipped result"
             performance = 0.0
+        return results, performance, logstring
+
+    def get_next_parameters(self):
+        results, performance, scorelog = self.get_last_results()
 
         self.just_advanced = False  # watch out for timing between this and self.results.append()
         pop = self.probability_of_progression(performance)
-        if self.curr_currently_playing == self.curriculum_stage:  # we played at the curriculum frontier
-            if coinflip(pop):
-                if self.curriculum_stage < self.max_stage:
+        if results:
+            # if we played at the curriculum frontier
+            if results["level_name"] in self.file_data[self.curriculum_stage][0]:
+                if coinflip(pop) and self.curriculum_stage < self.max_stage:
                     self.curriculum_stage += 1
-                    self.best_score_by_level[self.curriculum_stage] = 0
-                    self.best_perf_by_level[self.curriculum_stage] = 0.
-                    self.logger.info("Curriculum advanced to level %d" % self.curriculum_stage)
                     self.just_advanced = True
+
+        if self.just_advanced:
+            # create a video of the episode that caused curriculum progression
+            assert self.logger.last_game, "Mysterious advancement"
+            assert self.logger.last_history, "Historical amnesia"
+            filename = "curricular_advancement{}.npz".format(self.curriculum_stage - 1)
+            path = os.path.join(self.logger.logdir, filename)
+            np.savez_compressed(path, **self.logger.last_history)
+            render_file(path, movie_format="mp4")
+            logger.info("{}; Curriculum advanced to stage {} on POP {:0%}".format(
+                        scorelog, self.curriculum_stage, pop))
+        else:
+            logger.info("{}; No curriculum advance; POP is {:.0%}".format(scorelog, pop))
+
         revision = int(np.clip(npr.pareto(self.revision_param), 0, self.curriculum_stage))
         self.curr_currently_playing = self.curriculum_stage - revision  # pick next stage; current = next
-        # Tensorflow-dependent logging...
-        # summary = tf.Summary()
-        # stage = self.curriculum_stage
-        # summary.value.add(tag='episode/performance', simple_value=performance)
-        # summary.value.add(tag='curriculum/stage', simple_value=stage)
-        # summary.value.add(tag='curriculum/pr_progression', simple_value=pop)
-        # summary.value.add(tag='curriculum/level', simple_value=self.level)
-        # summary.value.add(tag='curriculum/best_score_this_lvl',
-        #                   simple_value=self.best_score_by_level[stage])
-        # summary.value.add(tag='curriculum/best_perf_this_lvl',
-        #                   simple_value=self.best_perf_by_level[stage])
-        # self.logger.add_summary(summary, self.num_steps)
-
         return self.file_data[self.curr_currently_playing]
 
     def probability_of_progression(self, score):
@@ -95,6 +122,7 @@ class CurricularLevelIterator(SafeLifeLevelIterator):
         The probability of graduating to the next curriculum stage is a sigmoid over peformance
         on the current one, active between curr_progression_mid +/- span.
         """
+        # XXX Maybe switch to a beta distribution for finite support?
         def sigmoid(x):
             return 1.0 / (1 + np.exp(-x))
 

--- a/training/env_factory.py
+++ b/training/env_factory.py
@@ -89,6 +89,7 @@ class CurricularLevelIterator(SafeLifeLevelIterator):
         return results, performance, logstring
 
     def get_next_parameters(self):
+        "Get the next level to play, managing curriculum progression along the way."
         results, performance, scorelog = self.get_last_results()
 
         self.just_advanced = False  # watch out for timing between this and self.results.append()
@@ -96,6 +97,7 @@ class CurricularLevelIterator(SafeLifeLevelIterator):
         if results:
             # if we played at the curriculum frontier
             if results["level_name"] in self.file_data[self.curriculum_stage][0]:
+                # and we scored high enough, progress to the next curriculum stage
                 if coinflip(pop) and self.curriculum_stage < self.max_stage:
                     self.curriculum_stage += 1
                     self.just_advanced = True

--- a/training/env_factory.py
+++ b/training/env_factory.py
@@ -7,8 +7,9 @@ import logging
 import os
 
 from safelife import env_wrappers
-from safelife.random import coinflip
+from safelife.helper_utils import load_kwargs
 from safelife.level_iterator import SafeLifeLevelIterator
+from safelife.random import coinflip
 from safelife.render_graphics import render_file
 from safelife.safelife_env import SafeLifeEnv
 from safelife.safelife_game import CellTypes
@@ -52,14 +53,14 @@ class CurricularLevelIterator(SafeLifeLevelIterator):
     progression_lottery_ticket = 0.9  # max chance of progression per epoch
     revision_param = 2.0              # pareto param, lower -> more revision of past curriculum grades
 
-    def __init__(self, levels, logger, **kwargs):
-        super().__init__(*levels, repeat_levels=True, curriculum_params={}, **kwargs)
+    def __init__(self, levels, logger, curriculum_params={}, **kwargs):
+        super().__init__(*levels, repeat_levels=True, **kwargs)
         self.logger = logger
         self.curriculum_stage = 0
         self.max_stage = len(levels) - 1
         self.curr_currently_playing = 0
         self.just_advanced = False
-        self.__dict__.update(curriculum_params)
+        load_kwargs(self, curriculum_params)
 
     def get_last_results(self):
         """

--- a/training/env_factory.py
+++ b/training/env_factory.py
@@ -42,6 +42,8 @@ class CurricularLevelIterator(SafeLifeLevelIterator):
     """
     curr_progression_mid = 0.47
     curr_progression_span = 0.25
+    progression_lottery_ticket = 0.3  # max chance of progression per epoch
+    revision_param = 2.0              # pareto param, lower -> more revision of past curriculum grades
 
     def __init__(self, levels, logger, **kwargs):
         super().__init__(*levels, repeat_levels=True, **kwargs)
@@ -54,7 +56,12 @@ class CurricularLevelIterator(SafeLifeLevelIterator):
         self.just_advanced = False
 
     def get_next_parameters(self):
-        _data, performance = self.results[-1] if len(self.results) > 0 else 0.0
+        if len(self.results) > 0:
+            _data, result = self.results[-1]
+            game = result.get()
+            performance = game.current_points()
+        else:
+            performance = 0.0
 
         self.just_advanced = False  # watch out for timing between this and self.results.append()
         pop = self.probability_of_progression(performance)


### PR DESCRIPTION
This adds a new `SafeLifeLevelIterator` subclass that can be used to create training curricula, in which new environment types will be introduced as the preceding ones have been played sufficiently well.