### PR TITLE
V1.1.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,18 @@
+# Version 1.1.1
+
+SafeLife v1.1.1 adds a few minor features and fixes a major performance bug in the training algorithms.
+
+- Fixed a bug in which `torch.tensor()` was being passed python lists instead of numpy arrays during training. The former is much slower than the latter, even when the lists can easily be converted to numpy arrays. After the fix training runs several times faster. See [PyTorch issue #13918](https://github.com/pytorch/pytorch/issues/13918) for more details.
+
+- Created an 'inaction baseline' option for the `env_wrappers.SimpleSideEffectPenalty` class. If `baseline='inaction'`, the side effect penalty will be relative to the counterfactual in which the agent took no actions rather than relative to the fixed starting state.
+
+- Added a convenience method to load data from SafeLife log (json) files. See `safelife_logger.load_safelife_log()` for more details.
+
+- Added a command to go back to previous levels when in interactive mode. Use the `<` and `>` keys to navigate to previous and next levels.
+
+- Tweaked the package requirements to avoid conflicts between later versions of pyglet and gym.
+
+
 # Version 1.1
 
 SafeLife v1.1 introduces many changes to make it easier to run SafeLife agents in a variety of settings. Some of these changes are backwards incompatible, so please read this carefully if you are upgrading from a previous version.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ ipython>=5.0
 tensorboard>=2.0,<3.0  # used for training, not part of the environment
 tensorboardX>=2.0,<3.0  # used for training
 torch>=1.3  # used for training
-pyglet==1.3.2
+pyglet>=1.3.2,<=1.5.0
 pyyaml>=3.12

--- a/safelife/safelife_game.py
+++ b/safelife/safelife_game.py
@@ -389,9 +389,8 @@ class GameState(object):
                 toggle_bits = CellTypes.powers * self.can_toggle_powers
                 toggle_bits |= CellTypes.rainbow_color * self.can_toggle_colors
                 board[y0, x0] ^= board[y1, x1] & toggle_bits
-        elif action == "RESTART":
-            # reward = -5
-            self.game_over = "RESTART"
+        elif action in ("RESTART", "ABORT LEVEL", "PREV LEVEL", "NEXT LEVEL"):
+            self.game_over = action
         return reward
 
     def execute_edit(self, command):
@@ -459,8 +458,8 @@ class GameState(object):
         elif command == "REVERT":
             if not self.revert():
                 return "No saved state; cannot revert."
-        elif command == "ABORT LEVEL":
-            self.game_over = "ABORT LEVEL"
+        elif command in ("ABORT LEVEL", "PREV LEVEL", "NEXT LEVEL"):
+            self.game_over = command
         self.update_exit_locs()
 
     def shift_board(self, dx, dy):

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ with open(os.path.join(base_dir, "README.md"), "rt", encoding="utf-8") as fh:
 
 setuptools.setup(
     name='safelife',
-    version='1.1',
+    version='1.1.1',
     author="Carroll L. Wainwright",
     author_email="carroll@partnershiponai.org",
     description="Safety benchmarks for reinforcement learning",
@@ -37,7 +37,7 @@ setuptools.setup(
         "scipy>=1.0.0",
         "gym>=0.12.5",
         "imageio>=2.5.0",
-        "pyglet==1.3.2",
+        "pyglet>=1.3.2,<=1.5.0",
         "pyyaml>=3.12",
     ],
     ext_modules=[

--- a/start-training
+++ b/start-training
@@ -39,6 +39,8 @@ parser.add_argument('--port', default=6006, type=int,
 parser.add_argument('--run-benchmarks', action="store_true",
     help="Don't do training; just run benchmarks on all benchmark levels.")
 parser.add_argument('--impact-penalty', default=0.0, type=float)
+parser.add_argument('--penalty-baseline',
+    choices=('starting-state', 'inaction'), default='starting-state')
 parser.add_argument('--env-type', choices=env_types)
 parser.add_argument('--algo', choices=('ppo', 'dqn'), default='ppo')
 parser.add_argument('--seed', default=None, type=int)
@@ -246,6 +248,7 @@ try:
         training_envs = safelife_env_factory(
             data_logger=data_logger, num_envs=16,
             impact_penalty=LinearSchedule(data_logger, t_penalty, [0, penalty]),
+            penalty_baseline=args.penalty_baseline,
             min_performance=LinearSchedule(data_logger, t_performance, [0.01, 0.5]),
             level_iterator=level_iterator,
         )

--- a/training/base_algo.py
+++ b/training/base_algo.py
@@ -3,6 +3,7 @@ import glob
 import logging
 
 import torch
+import numpy as np
 
 from .utils import nested_getattr, nested_setattr
 
@@ -135,6 +136,17 @@ class BaseAlgo(object):
                     logger.error("Cannot load key '%s'", key)
 
         self._last_checkpoint = self.num_steps
+
+    def tensor(self, data, dtype):
+        """
+        Shorthand for creating a tensor with the current compute device.
+
+        Note that this is *much* faster than passing data in list form to
+        ``torch.tensor`` directly, at least as of torch v1.3.
+        See https://github.com/pytorch/pytorch/issues/13918 for more details.
+        """
+        data = np.asanyarray(data)
+        return torch.as_tensor(data, device=self.compute_device, dtype=dtype)
 
     def take_one_step(self, envs):
         """

--- a/training/dqn.py
+++ b/training/dqn.py
@@ -140,7 +140,7 @@ class DQN(BaseAlgo):
             e.last_state if hasattr(e, 'last_state') else e.reset()
             for e in envs
         ]
-        tensor_states = torch.tensor(states, device=self.compute_device, dtype=torch.float32)
+        tensor_states = self.tensor(states, torch.float32)
         qvals = self.training_model(tensor_states).detach().cpu().numpy()
 
         num_states, num_actions = qvals.shape
@@ -171,11 +171,11 @@ class DQN(BaseAlgo):
         state, action, reward, next_state, done = \
             self.replay_buffer.sample(self.training_batch_size)
 
-        state = torch.tensor(state, device=self.compute_device, dtype=torch.float32)
-        next_state = torch.tensor(next_state, device=self.compute_device, dtype=torch.float32)
-        action = torch.tensor(action, device=self.compute_device, dtype=torch.int64)
-        reward = torch.tensor(reward, device=self.compute_device, dtype=torch.float32)
-        done = torch.tensor(done, device=self.compute_device, dtype=torch.float32)
+        state = self.tensor(state, torch.float32)
+        next_state = self.tensor(next_state, torch.float32)
+        action = self.tensor(action, torch.int64)
+        reward = self.tensor(reward, torch.float32)
+        done = self.tensor(done, torch.float32)
 
         q_values = self.training_model(state)
         next_q_values = self.target_model(next_state).detach()

--- a/training/env_factory.py
+++ b/training/env_factory.py
@@ -52,6 +52,7 @@ def safelife_env_factory(
         min_performance=None,
         data_logger=None,
         impact_penalty=None,
+        penalty_baseline='starting-state',
         testing=False):
     """
     Factory for creating SafeLifeEnv instances with useful wrappers.
@@ -81,7 +82,7 @@ def safelife_env_factory(
             env = env_wrappers.ExtraExitBonus(env)
         if impact_penalty is not None:
             env = env_wrappers.SimpleSideEffectPenalty(
-                env, penalty_coef=impact_penalty)
+                env, penalty_coef=impact_penalty, baseline=penalty_baseline)
         if min_performance is not None:
             env = env_wrappers.MinPerformanceScheduler(
                 env, min_performance=min_performance)

--- a/training/ppo.py
+++ b/training/ppo.py
@@ -64,7 +64,7 @@ class PPO(BaseAlgo):
             e.last_obs if hasattr(e, 'last_obs') else e.reset()
             for e in envs
         ]
-        tensor_states = torch.tensor(states, device=self.compute_device, dtype=torch.float32)
+        tensor_states = self.tensor(states, torch.float32)
         values, policies = self.model(tensor_states)
         values = values.detach().cpu().numpy()
         policies = policies.detach().cpu().numpy()
@@ -101,8 +101,7 @@ class PPO(BaseAlgo):
             for _ in range(steps_per_env)
         ]
         final_states = [e.last_obs for e in self.training_envs]
-        tensor_states = torch.tensor(
-            final_states, device=self.compute_device, dtype=torch.float32)
+        tensor_states = self.tensor(final_states, torch.float32)
         final_vals = self.model(tensor_states)[0].detach().cpu().numpy()
         values = np.array([s.values for s in steps] + [final_vals])
         rewards = np.array([s.rewards for s in steps])
@@ -129,7 +128,7 @@ class PPO(BaseAlgo):
             if flat:
                 x = np.asanyarray(x)
                 x = x.reshape(-1, *x.shape[2:])
-            return torch.tensor(x, device=self.compute_device, dtype=dtype)
+            return torch.as_tensor(x, device=self.compute_device, dtype=dtype)
 
         self.num_steps += actions.size
 


### PR DESCRIPTION
SafeLife v1.1.1 adds a few minor features and fixes a major performance bug in the training algorithms.

- Fixed a bug in which `torch.tensor()` was being passed python lists instead of numpy arrays during training. The former is much slower than the latter, even when the lists can easily be converted to numpy arrays. After the fix training runs several times faster. See [PyTorch issue #13918](https://github.com/pytorch/pytorch/issues/13918) for more details.

- Created an 'inaction baseline' option for the `env_wrappers.SimpleSideEffectPenalty` class. If `baseline='inaction'`, the side effect penalty will be relative to the counterfactual in which the agent took no actions rather than relative to the fixed starting state.

- Added a convenience method to load data from SafeLife log (json) files. See `safelife_logger.load_safelife_log()` for more details.

- Added a command to go back to previous levels when in interactive mode. Use the `<` and `>` keys to navigate to previous and next levels.

- Tweaked the package requirements to avoid conflicts between later versions of pyglet and gym.
