### PR TITLE
Fix wandb logging failure reported

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ plays
 .*.swp
 wandb/
 ./tmp/
+.idea/

--- a/training/logging_setup.py
+++ b/training/logging_setup.py
@@ -73,7 +73,7 @@ def setup_data_logger(data_dir, episode_type):
     if data_dir is not None:
         os.makedirs(data_dir, exist_ok=True)
 
-    if config.get('_wandb'):
+    if config.get('_wandb') is not None:
         import wandb
         summary_writer = False
     elif config['run_type'] == 'train':


### PR DESCRIPTION
closes #28 

changed `if config.get("_wandb"):` to `if config.get("_wandb") is not None:`

also added `.idea/` to git ignore for pycharm users